### PR TITLE
fix error on case-sensitive filesystems

### DIFF
--- a/4_better_player/main.lua
+++ b/4_better_player/main.lua
@@ -7,7 +7,7 @@ bump = require 'libs.bump.bump'
 Gamestate = require 'libs.hump.gamestate'
 
 -- Pull in each of our game states
-local mainMenu = require 'gamestates.mainmenu'
+local mainMenu = require 'gamestates.mainMenu'
 local gameLevel1 = require 'gamestates.gameLevel1'
 local pause = require 'gamestates.pause'
 


### PR DESCRIPTION
This throws an error when run on a system with a case-sensitive filesystem (practically any Linux distro). The M needs to be uppercase.

Thank you for your wonderful tutorials! 